### PR TITLE
force boolean expression in set and deleteFrom functions

### DIFF
--- a/jam-core/src/main/scala/jam/sql/sql-ast.scala
+++ b/jam-core/src/main/scala/jam/sql/sql-ast.scala
@@ -267,7 +267,10 @@ trait HasUpdate { self: Node =>
 }
 
 trait HasDeleteFrom { self: Node =>
-  def deleteFrom[F[_], A](fa: F[A])(implicit ev: TFrom[F, A]): DeleteFromNode[F, A] =
+  def deleteFrom[F[_], A](fa: F[A])(exp: Expression[Boolean])(implicit ev: TFrom[F, A]): DMLWhereNode[Expression, Boolean] =
+    DeleteFromNode(self, fa, ev).where(exp)
+
+  def deleteAllFrom[F[_], A](fa: F[A])(implicit ev: TFrom[F, A]): DeleteFromNode[F, A] =
     DeleteFromNode(self, fa, ev)
 }
 
@@ -380,7 +383,10 @@ case class ValuesNode[F[_], A](parent: Node, value: TraversableOnce[F[A]], tv: T
 case class InsertIntoSelect[A](parent: Node, value: DQLNode[A])                               extends DMLNode[A]
 
 case class UpdateNode[F[_], A](parent: Node, value: F[A], tu: TUpdate[F, A]) extends Node {
-  def set[T](x: T, xs: T*)(implicit ev: TSet[T]): SetNode[T] =
+  def set[T](x: T, xs: T*)(exp: Expression[Boolean])(implicit ev: TSet[T]): DMLWhereNode[Expression, Boolean] =
+    SetNode(this, x +: xs, ev).where(exp)
+
+  def setAllTable[T](x: T, xs: T*)(implicit ev: TSet[T]): SetNode[T] =
     SetNode(this, x +: xs, ev)
 }
 case class SetNode[A](parent: Node, value: TraversableOnce[A], ts: TSet[A]) extends DMLNode[A] with HasDMLWhere

--- a/jam-example/src/main/scala/jam/example/e000/00-start-here.scala
+++ b/jam-example/src/main/scala/jam/example/e000/00-start-here.scala
@@ -134,26 +134,23 @@ object Main {
 
     DML
       .update(c)
-      .set(c.name := "some name".param, c.code := "some-code".param)
+      .setAllTable(c.name := "some name".param, c.code := "some-code".param)
 
     DML
       .update(c)
-      .set(c.name := DQL.select("some name".literal).enclose, c.population := c.population - 1L.literal)
-      .where((c.code :: c.name) in ("a".literal :: "b".param))
+      .set(c.name := DQL.select("some name".literal).enclose, c.population := c.population - 1L.literal)((c.code :: c.name) in ("a".literal :: "b".param))
       .update
       .transactionally
       .unsafeToFuture(db)
 
     DML
-      .deleteFrom(c)
-      .where(c.population <= 0L.param)
+      .deleteFrom(c)(c.population <= 0L.param)
       .update
       .transactionally
       .unsafeToFuture(db)
 
     DML
-      .deleteFrom(c)
-      .where(c.population in DQL.select(1L.literal))
+      .deleteFrom(c)(c.population in DQL.select(1L.literal))
       .update
       .transactionally
       .unsafeToFuture(db)

--- a/jam-example/src/main/scala/jam/example/e000/SlickExample.scala
+++ b/jam-example/src/main/scala/jam/example/e000/SlickExample.scala
@@ -32,8 +32,7 @@ object SlickExample {
 
     DML
       .update(country)
-      .set(country.name := Name("").param, country.code := CountryCode("").param)
-      .where(country.name === Name("").param)
+      .set(country.name := Name("").param, country.code := CountryCode("").param)(country.name === Name("").param)
 
     val query =
       DQL

--- a/jam-example/src/main/scala/jam/example/e003/example-03.scala
+++ b/jam-example/src/main/scala/jam/example/e003/example-03.scala
@@ -26,7 +26,7 @@ class SlickCompanyService(implicit val ns: NamingStrategy) extends CompanyServic
     DML.insertInto(e).values(instance.param).update
 
   def update(uuid: CompanyUUID, data: CompanyData): DBIO[Int] =
-    DML.update(e).set(e.data := data.param).where(e.uuid === uuid.param).update
+    DML.update(e).set(e.data := data.param)(e.uuid === uuid.param).update
 
   DQL
     .from(


### PR DESCRIPTION
- To Avoid delete or update all table by missing `where clause`, I add anther boolean expression parameter to `set` and `deleteFrom` functions 

- If user need to delete or update all table he can use `setAllTable` or `deleteAllfrom` functions 